### PR TITLE
Fix null reference error in task filtering logic

### DIFF
--- a/arrowclient/components/tasks/addConnection.js
+++ b/arrowclient/components/tasks/addConnection.js
@@ -155,7 +155,7 @@ function handleInputCore(e) {
 
   const matches = allTasks
     .filter(
-      (taskItem) => taskItem.name.toLowerCase().includes(currentLineText) && taskItem.id !== reData.selectedScribe,
+      (taskItem) => taskItem.name && taskItem.name.toLowerCase().includes(currentLineText) && taskItem.id !== reData.selectedScribe,
     )
     .sort((a, b) => {
       const difference = b.leadsCount + b.blocksCount - (a.leadsCount + a.blocksCount)


### PR DESCRIPTION
## Summary
Added a null check for `taskItem.name` before calling `.toLowerCase()` to prevent runtime errors when filtering tasks with missing name properties.

## Key Changes
- Added null/undefined check for `taskItem.name` in the filter predicate within `handleInputCore()` function
- This prevents potential "Cannot read property 'toLowerCase' of undefined" errors when processing tasks that lack a name property

## Implementation Details
The filter now validates that `taskItem.name` exists before attempting to call `.toLowerCase()` on it. This defensive programming approach ensures the application gracefully handles malformed task data without crashing during the connection input handling process.

https://claude.ai/code/session_01Jy8WSpzNUkHVp4jEw58VuH