### PR TITLE
Consolidate version management to package.json

### DIFF
--- a/arrowclient/logic/send.js
+++ b/arrowclient/logic/send.js
@@ -7,8 +7,9 @@ import data from "~/logic/data.js"
 import { makevisible } from "~/logic/makevisible"
 import { safeSetLocalStorageItem } from "~/logic/sync.js"
 import { socket } from "~/logic/socket.js"
-import VERSION from "~/../shared/version.js"
 import Graph from "~/../shared/graph.js"
+
+const VERSION = __APP_VERSION__
 
 import { v4 as uuidv4 } from "uuid"
 
@@ -44,8 +45,11 @@ export function inputSocket() {
   socket.on("version", function (msg) {
     reData.version = msg.version
     if (msg && msg.version != VERSION) {
-      const safeVersion = encodeURIComponent(msg.version) // Надежное экранирование версии
-      window.location.href = `${window.location.pathname}?version=${safeVersion}`
+      const reloadKey = "version_reload_" + msg.version
+      if (!sessionStorage.getItem(reloadKey)) {
+        sessionStorage.setItem(reloadKey, "1")
+        window.location.reload()
+      }
     }
   })
   socket.on("disconnect", function () {

--- a/arrowclient/vite.config.mjs
+++ b/arrowclient/vite.config.mjs
@@ -1,8 +1,10 @@
 import { defineConfig } from "vite"
-import { readdirSync } from "fs"
+import { readdirSync, readFileSync } from "fs"
 import { resolve } from "path"
 import tailwindcss from "tailwindcss"
 import autoprefixer from "autoprefixer"
+
+const pkg = JSON.parse(readFileSync(resolve(__dirname, "../package.json"), "utf-8"))
 
 function getBlogEntries() {
   const blogDir = resolve(__dirname, "info")
@@ -21,6 +23,9 @@ function getBlogEntries() {
 }
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   build: {
     rollupOptions: {
       input: {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.4.16",
   "type": "module",
   "dependencies": {
     "create-vite": "^4.4.1",

--- a/server/socket.js
+++ b/server/socket.js
@@ -2,7 +2,8 @@ import serviceAccount from "../firebase.config.js"
 import admin from "firebase-admin"
 import { addUser, getUser } from "./user.js"
 
-import version from "../shared/version.js"
+import { readFileSync } from "fs"
+const { version } = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"))
 import {
   syncTasks,
   removeCollaborator,

--- a/shared/version.js
+++ b/shared/version.js
@@ -1,1 +1,0 @@
-export default "1.4.16"


### PR DESCRIPTION
## Summary
Refactored version management to use a single source of truth (`package.json`) instead of maintaining a separate `shared/version.js` file. This eliminates duplication and simplifies version updates across the application.

## Key Changes
- **Removed** `shared/version.js` file that was manually maintained
- **Updated client** (`arrowclient/logic/send.js`): Changed to use `__APP_VERSION__` injected by Vite at build time
- **Updated server** (`server/socket.js`): Changed to read version directly from `package.json` at runtime
- **Updated build config** (`arrowclient/vite.config.mjs`): Added Vite `define` configuration to inject `__APP_VERSION__` from `package.json` during build
- **Updated** `package.json`: Added explicit `"version": "1.4.16"` field as the single source of truth

## Implementation Details
- The client now receives the version as a build-time constant via Vite's `define` option, ensuring the version is baked into the bundle
- The server reads the version from `package.json` at runtime, allowing version checks without rebuilding
- Improved version mismatch handling: Changed from URL-based reload with query parameters to a simpler `window.location.reload()` with session storage deduplication to prevent reload loops

https://claude.ai/code/session_019U9cZ3gg9tyz2J3VEuSMJg