### PR TITLE
fix: revert depth back to max, keep pureDepth as min

### DIFF
--- a/shared/graph.js
+++ b/shared/graph.js
@@ -242,17 +242,16 @@ class Graph {
       if (degree === 0) queue.push(nodeId)
     })
 
-    // Initialize depths to Infinity so Math.min picks the shortest path
+    // Initialize depths
     this.nodes.forEach((nodeData) => {
-      nodeData.depth = Infinity
+      nodeData.depth = 0
       nodeData.pureDepth = Infinity
     })
 
-    // Root nodes (in-degree 0) start at depth 0
+    // Root nodes (in-degree 0) start at pureDepth 0
     queue.forEach((nodeId) => {
       const nodeData = this.nodes.get(nodeId)
       if (nodeData) {
-        nodeData.depth = 0
         nodeData.pureDepth = 0
       }
     })
@@ -266,7 +265,7 @@ class Graph {
       const inc = incFor(parentId, kind)
       const parentDepth = this.nodes.get(parentId)?.depth ?? 0
       const parentPureDepth = this.nodes.get(parentId)?.pureDepth ?? 0
-      child.depth = Math.min(child.depth, parentDepth + inc)
+      child.depth = Math.max(child.depth ?? 0, parentDepth + inc)
       child.pureDepth = Math.min(child.pureDepth, parentPureDepth + 1)
 
       inDegree.set(childId, (inDegree.get(childId) || 0) - 1)


### PR DESCRIPTION
depth should use longest path (Math.max) as before, only pureDepth should use shortest path (Math.min).

https://claude.ai/code/session_019U9cZ3gg9tyz2J3VEuSMJg